### PR TITLE
Favor `@Value` to retrieve property value in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ class TodoControllerTests {
 
     @InjectWireMock("user-service")
     private WireMockServer wiremock;
-    
-    @Autowired
-    private Environment env;
+
+    @Value("${user-client.url}")
+    private String wiremockUrl; // injects the base URL of the WireMockServer instance
 
     @Test
     void aTest() {
-        env.getProperty("user-client.url"); // returns a URL to WireMockServer instance
         wiremock.stubFor(...);
     }
 }


### PR DESCRIPTION
I propose to use `@Value` to retrieve the property value in the README example, more declarative than the usage of `Environment`.

Of course, feel free to close it if you don't like the idea 🙂 

