### PR TITLE
fix: change jetty-ee10-bom dependency type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 project("wiremock-spring-boot", {
 	dependencies {
 		implementation platform("org.eclipse.jetty:jetty-bom:12.1.3")
-		implementation "org.eclipse.jetty.ee10:jetty-ee10-bom:12.1.3"
+		implementation platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.1.3")
 		api "org.wiremock:wiremock-jetty12:3.13.1"
 
 		// Don't want to force these versions on the user


### PR DESCRIPTION
add `platform(...)` to the jetty-ee10-bom dependency to make it resolve as `pom` instead of `jar` when using maven.

## References

#161

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
