### PR TITLE
Add support for standalone @ConfigureWireMock

### DIFF
--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/ConfigureWireMock.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/ConfigureWireMock.java
@@ -4,9 +4,13 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -14,7 +18,10 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Maciej Walkowiak
  */
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(ConfigureWireMocks.class)
+@ExtendWith(org.wiremock.spring.internal.WireMockSpringJunitExtension.class)
 public @interface ConfigureWireMock {
   public static final List<String> DEFAULT_FILES_UNDER_DIRECTORY =
       List.of(

--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/ConfigureWireMocks.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/ConfigureWireMocks.java
@@ -1,0 +1,14 @@
+package org.wiremock.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfigureWireMocks {
+  ConfigureWireMock[] value();
+}

--- a/wiremock-spring-boot/src/test/java/usecases/StandaloneConfigureWireMockTest.java
+++ b/wiremock-spring-boot/src/test/java/usecases/StandaloneConfigureWireMockTest.java
@@ -1,0 +1,35 @@
+package usecases;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.wiremock.spring.ConfigureWireMock;
+import org.wiremock.spring.InjectWireMock;
+
+@SpringBootTest
+@ConfigureWireMock(name = "user-service", baseUrlProperties = "user-service.url")
+class StandaloneConfigureWireMockTest {
+
+  @InjectWireMock("user-service")
+  private WireMockServer userService;
+
+  @Value("${user-service.url}")
+  private String userServiceUrl;
+
+  @Test
+  void wireMockIsStarted() {
+    assertThat(userService).isNotNull();
+    assertThat(userServiceUrl).isNotBlank();
+
+    WireMock.stubFor(get("/test").willReturn(aResponse().withStatus(200)));
+
+    RestAssured.when().get(userServiceUrl + "/test").then().statusCode(200);
+  }
+}


### PR DESCRIPTION
Enables @ConfigureWireMock to work on plain JUnit 5 test classes without needing Spring Boot's test context. Also made it repeatable to support multiple configurations. Fixes #193