### PR TITLE
chore: disable HTTP for HTTPS only config

### DIFF
--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
@@ -45,6 +45,7 @@ public class WireMockServerCreator {
 
     final int serverHttpPort = portResolver.getServerHttpPortProperty(options);
     final boolean httpEnabled = serverHttpPort != PORT_DISABLED;
+    serverOptions.httpDisabled(!httpEnabled);
     if (httpEnabled) {
       serverOptions.port(serverHttpPort);
     }

--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
@@ -100,7 +100,7 @@ public class WireMockSpringJunitExtension
       final String host = "localhost";
       if (isHttps) {
         WireMock.configureFor(
-          WireMock.create().https().host(host).port(port).build());
+            WireMock.create().https().host(host).port(port).build());
       } else {
         WireMock.configureFor(WireMock.create().http().host(host).port(port).build());
       }

--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
@@ -88,18 +88,21 @@ public class WireMockSpringJunitExtension
       }
     }
     if (wiremock != null) {
+      final boolean isHttps = wiremock.isHttpsEnabled();
+      final int port = isHttps ? wiremock.httpsPort() : wiremock.port();
+
       LOGGER.info(
           "Configuring WireMock for default instance, '"
               + wireMockName
               + "' on '"
-              + wiremock.port()
+              + port
               + "'.");
       final String host = "localhost";
-      if (wiremock.isHttpsEnabled()) {
+      if (isHttps) {
         WireMock.configureFor(
-            WireMock.create().https().host(host).port(wiremock.httpsPort()).build());
+          WireMock.create().https().host(host).port(port).build());
       } else {
-        WireMock.configureFor(WireMock.create().http().host(host).port(wiremock.port()).build());
+        WireMock.configureFor(WireMock.create().http().host(host).port(port).build());
       }
     }
   }

--- a/wiremock-spring-boot/src/test/java/usecases/HttpsOnlyTest.java
+++ b/wiremock-spring-boot/src/test/java/usecases/HttpsOnlyTest.java
@@ -5,6 +5,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -58,5 +59,11 @@ class HttpsOnlyTest {
     RestAssured.when().get(this.wiremockHttpsUrl + "/with-default-client").then().statusCode(202);
 
     assertThat(WireMock.findAll(anyRequestedFor(anyUrl()))).hasSize(1);
+  }
+
+  @Test
+  void testHttpDisabled() {
+    assertThat(wiremock.isHttpEnabled()).isFalse();
+    assertThatThrownBy(() -> wiremock.port()).isExactlyInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
Currently, for a HTTPS only config like
```java
@EnableWireMock(
  @ConfigureWireMock(port = -1, httpsPort = 0)
)
```
the `WireMockServer`'s `httpDisabled` property is not set. This means that the default value (`8080`) is pulled from `new WireMockConfiguration()`, instead of no HTTP port.

In this change, I'm simply setting the `httpDisabled` property according to the config.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
