### PR TITLE
fix: stop WireMock servers when context closes during AOT processing

### DIFF
--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
@@ -16,6 +16,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextClosedEvent;
@@ -83,10 +84,14 @@ public class WireMockServerCreator {
     context.addApplicationListener(
         event -> {
           if (event instanceof ContextClosedEvent) {
-            this.logger.info("Stopping WireMockServer with name '{}'", options.name());
-            newServer.stop();
+            this.stopWireMockServer(options.name(), newServer);
           }
         });
+
+    if (context.getBeanFactory() instanceof DefaultSingletonBeanRegistry singletonBeanRegistry) {
+      singletonBeanRegistry.registerDisposableBean(
+          options.name() + "-shutdown", () -> this.stopWireMockServer(options.name(), newServer));
+    }
 
     if (httpEnabled) {
       Arrays.stream(options.baseUrlProperties())
@@ -148,6 +153,13 @@ public class WireMockServerCreator {
     }
 
     return newServer;
+  }
+
+  private void stopWireMockServer(final String name, final WireMockServer server) {
+    if (server.isRunning()) {
+      this.logger.info("Stopping WireMockServer with name '{}'", name);
+      server.stop();
+    }
   }
 
   private void configureMappings(ConfigureWireMock options, WireMockConfiguration serverOptions) {

--- a/wiremock-spring-boot/src/test/java/usecases/AotProcessingTest.java
+++ b/wiremock-spring-boot/src/test/java/usecases/AotProcessingTest.java
@@ -1,0 +1,58 @@
+package usecases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.aot.TestContextAotGenerator;
+import org.wiremock.spring.EnableWireMock;
+
+class AotProcessingTest {
+
+  @SpringBootTest
+  @EnableWireMock
+  static class AotProcessedTest {}
+
+  @Test
+  void wireMockIsStoppedWhenAotProcessingClosesContext() throws InterruptedException {
+    final Set<String> poolsBefore =
+        this.nonDaemonJettyThreads().stream()
+            .map(this::jettyThreadPoolName)
+            .collect(Collectors.toSet());
+
+    new TestContextAotGenerator(new InMemoryGeneratedFiles(), new RuntimeHints(), true)
+        .processAheadOfTime(Stream.of(AotProcessedTest.class));
+
+    final Set<Thread> leaked = this.leakedJettyThreads(poolsBefore);
+    final long deadline = System.currentTimeMillis() + 10_000;
+    while (!leaked.isEmpty() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(100);
+      leaked.removeIf(thread -> !thread.isAlive());
+    }
+    assertThat(leaked)
+        .as("non-daemon Jetty threads still running after AOT processing closed the context")
+        .isEmpty();
+  }
+
+  private Set<Thread> leakedJettyThreads(final Set<String> poolsBefore) {
+    return this.nonDaemonJettyThreads().stream()
+        .filter(thread -> !poolsBefore.contains(this.jettyThreadPoolName(thread)))
+        .collect(Collectors.toSet());
+  }
+
+  private Set<Thread> nonDaemonJettyThreads() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .filter(thread -> !thread.isDaemon())
+        .filter(thread -> thread.getName().startsWith("qtp"))
+        .collect(Collectors.toSet());
+  }
+
+  private String jettyThreadPoolName(final Thread thread) {
+    return thread.getName().replaceFirst("-\\d+$", "");
+  }
+}


### PR DESCRIPTION
Fixes #199

## Problem

When a `@SpringBootTest` class uses `@EnableWireMock`, Gradle's `processTestAot` (`SpringBootTestAotProcessor`) hangs forever. During test AOT processing, the test application context is loaded and closed outside the JUnit lifecycle:

- `TestContextAotGenerator` loads the context via `refreshForAotProcessing()`, which runs `prepareRefresh()` but never initializes the application event multicaster.
- When the generator closes the context (try-with-resources), `doClose()` publishes the `ContextClosedEvent` into the still-active `earlyApplicationEvents` set, so it is never delivered.
- The library's only shutdown hook was an `ApplicationListener<ContextClosedEvent>`, so the WireMock servers were never stopped and their non-daemon Jetty `qtp*` threads kept the AOT processing JVM alive after `main()` returned. Gradle waits on the forked process forever.

## Fix

`doClose()` still destroys singletons even in that path, so each started server is now **also** registered as a disposable bean in the singleton registry. The existing `ContextClosedEvent` listener is kept for the regular lifecycle, and both paths route through a single stop method guarded by `server.isRunning()`, so the server is never stopped twice.

An alternative considered was skipping server startup entirely when running under AOT processing (`spring.aot.processing` property). Rejected: it would require faking the injected base URL/port properties so context loading still succeeds, and it makes the AOT pass behave differently from a regular context load. Stopping the servers when the context that started them is closed fixes the root cause without behavior divergence.

## Testing

- New regression test `AotProcessingTest` runs `TestContextAotGenerator.processAheadOfTime()` against an `@EnableWireMock` test class — the same context load + close as `SpringBootTestAotProcessor`, outside JUnit's `SpringExtension` — and asserts no new non-daemon `qtp*` Jetty threads survive the context close. Fails without the fix, passes with it.
- Full `./gradlew build` green.
- Verified end-to-end against the reproducer from #199 (https://github.com/moyis/wiremock-aot-bug, Spring Boot 4.1.0, JDK 25): with the released 4.2.1 the AOT processor JVM stays alive indefinitely (jstack shows the WireMock Jetty `qtp*` threads); with this patch `./gradlew processTestAot` completes in seconds — the log shows Jetty shutting down when the AOT context is closed.